### PR TITLE
Allow digits in JIRA Project IDs

### DIFF
--- a/plugin/src/main/java/com/jitlab/connect/servlet/UtilityParser.java
+++ b/plugin/src/main/java/com/jitlab/connect/servlet/UtilityParser.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 
 public class UtilityParser {
     private static final Logger log = LoggerFactory.getLogger(JitLabConnect.class);
-    private static final Pattern pattern = Pattern.compile("(?<!([A-Za-z]{1,10})-?)[A-Z0-9]+-\\d+");
+    private static final Pattern pattern = Pattern.compile("((?<!([A-Za-z]{1,10})-?)[A-Z0-9]+-\\d+)");
 
     public static JitLabRequest parseRequest(String requestBody) {
         try {

--- a/plugin/src/main/java/com/jitlab/connect/servlet/UtilityParser.java
+++ b/plugin/src/main/java/com/jitlab/connect/servlet/UtilityParser.java
@@ -19,7 +19,7 @@ import java.util.regex.Pattern;
 
 public class UtilityParser {
     private static final Logger log = LoggerFactory.getLogger(JitLabConnect.class);
-    private static final Pattern pattern = Pattern.compile("((?<!([A-Za-z]{1,10})-?)[A-Z]+-\\d+)");
+    private static final Pattern pattern = Pattern.compile("(?<!([A-Za-z]{1,10})-?)[A-Z0-9]+-\\d+");
 
     public static JitLabRequest parseRequest(String requestBody) {
         try {


### PR DESCRIPTION
I've ran across the following problem: if project id contains digits (like `TEST123`) it cannot match the existing regexps and it cannot find any issues (like `TEST123-1234`).

I've updated the regular expression. Could you please merge this ASAP, so I can use this in my JIRA instance :D